### PR TITLE
load custom embug snippet from s3 bucket

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,2 +1,3 @@
-REACT_APP_EVENTS_ENDPOINT=https://w34a189qel.execute-api.us-east-1.amazonaws.com/prod/events
-REACT_APP_ORG_ID=6ee0295b-2f37-493f-bf8a-fdb459ab50e8
+REACT_APP_EVENTS_ENDPOINT=https://6j4b8vnwrd.execute-api.us-west-2.amazonaws.com/prod/events
+REACT_APP_ORG_ID=4bac72a3-8b3d-4042-bcf6-854466fc3632
+REACT_APP_EMBUG_SNIPPET_URL=https://us-west-2-embug-snippet.s3.us-west-2.amazonaws.com/embed.min.js

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,6 @@ associate_commits:
 
 upload_sourcemaps:
 	sentry-cli releases -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) files $(VERSION) \
-	upload-sourcemaps --url-prefix "~/$(PREFIX)" --validate build/$(PREFIX)
+		upload-sourcemaps --url-prefix "~/$(PREFIX)" --validate build/$(PREFIX)
 run:
 	npm run build && npx serve build

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,6 @@ associate_commits:
 
 upload_sourcemaps:
 	sentry-cli releases -o $(SENTRY_ORG) -p $(SENTRY_PROJECT) files $(VERSION) \
-		upload-sourcemaps --url-prefix "~/$(PREFIX)" --validate build/$(PREFIX)
+	upload-sourcemaps --url-prefix "~/$(PREFIX)" --validate build/$(PREFIX)
+run:
+	npm run build && npx serve build

--- a/public/index.html
+++ b/public/index.html
@@ -25,33 +25,14 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>Reactshoppe</title>
+    <script type="text/javascript" src="%REACT_APP_EMBUG_SNIPPET_URL%"></script>
     <script type="text/javascript">
-
-      window.addEventListener('unhandledrejection', function(event) {
-        // the event object has two special properties:
-        console.log(event.promise); // [object Promise] - the promise that generated the error
-        console.log(event.reason); // Error: Whoops! - the unhandled error object
-      });
-
-      window.addEventListener('error', function(event) {
-        const { message, filename, lineno, colno } = event;
-        const payload = {
-          orgId: '%REACT_APP_ORG_ID%',
-          error: { message, filename, lineno, colno },
-          extraData: { fullstoryUrl: FS.getCurrentSessionURL(true) }
-        };
-
-        console.log(JSON.stringify(payload));
-
-        fetch('%REACT_APP_EVENTS_ENDPOINT%', {
-          method: 'post',
-          body: JSON.stringify(payload)
-        }).then(function(response) {
-          return response.json();
-        }).then(function(data) {
-          console.log(data);
-        });
-      });
+        const app = window[window._embug_namespace];
+        app.addEventProcessor((e) => {
+            e.extraData = { fullstoryUrl: FS.getCurrentSessionURL(true) }
+            return e;
+        })
+        app.init({orgId: "%REACT_APP_ORG_ID%", eventsEndpoint: "%REACT_APP_EVENTS_ENDPOINT%" })
     </script>
   </head>
   <body>


### PR DESCRIPTION
This pull request changes the way reactshoppe sends errors to embug; it loads the code for embug from an s3 bucket instead. Additionally, there is a new URL added to the environment file for the destination of the embug snippet. It also adds an additional makefile command to capture the build/run process.

[ch157390]